### PR TITLE
feat: Implement Command Palette

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "type",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-progress": "^1.1.7",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-separator": "^1.1.7",
@@ -15,6 +16,7 @@
         "@radix-ui/react-switch": "^1.2.5",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
         "lucide-react": "^0.525.0",
         "next": "15.3.4",
         "react": "^19.0.0",
@@ -1603,6 +1605,41 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.14.tgz",
+      "integrity": "sha512-+CpweKjqpzTmwRwcYECQcNYbI8V9VSQt0SNFKeEBLgfucbsLssU6Ppq7wUdNXEGb573bMjFhVjKVll8rmV6zMw==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.10",
+        "@radix-ui/react-focus-guards": "1.1.2",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-direction": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
@@ -1735,6 +1772,29 @@
       "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.4.tgz",
+      "integrity": "sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
@@ -3980,6 +4040,21 @@
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/color": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-progress": "^1.1.7",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-separator": "^1.1.7",
@@ -20,6 +21,7 @@
     "@radix-ui/react-switch": "^1.2.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "lucide-react": "^0.525.0",
     "next": "15.3.4",
     "react": "^19.0.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { inter, robotoMono } from '@/lib/fonts';
 import { Header } from '@/components/layout/Header';
 import { Footer } from '@/components/layout/Footer';
+import { CommandPalette } from '@/components/core/CommandPalette';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -24,6 +25,7 @@ export default function RootLayout({
           <main className="container mx-auto flex-1 px-6 py-8">{children}</main>
           <Footer />
         </div>
+        <CommandPalette />
       </body>
     </html>
   );

--- a/src/components/core/CommandPalette.tsx
+++ b/src/components/core/CommandPalette.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from '@/components/ui/command';
+import { useGameStore } from '@/store/useGameStore';
+
+export function CommandPalette() {
+  const [open, setOpen] = useState(false);
+
+  // Zustand store actions
+  const setTestConfig = useGameStore((state) => state.setTestConfig);
+  const resetGame = useGameStore((state) => state.resetGame);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Check for Ctrl+K (Windows/Linux) or Cmd+K (Mac)
+      if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
+        e.preventDefault();
+        setOpen((open) => !open);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  const handleCommand = (callback: () => void) => {
+    setOpen(false);
+    callback();
+  };
+
+  return (
+    <CommandDialog open={open} onOpenChange={setOpen}>
+      <CommandInput placeholder="Type a command or search..." />
+      <CommandList>
+        <CommandEmpty>No results found.</CommandEmpty>
+
+        <CommandGroup heading="Game Controls">
+          <CommandItem onSelect={() => handleCommand(() => resetGame())}>
+            <span>Reset Game</span>
+          </CommandItem>
+        </CommandGroup>
+
+        <CommandSeparator />
+
+        <CommandGroup heading="Duration">
+          <CommandItem
+            onSelect={() =>
+              handleCommand(() => setTestConfig({ duration: 30 }))
+            }
+          >
+            <span>30 seconds</span>
+          </CommandItem>
+          <CommandItem
+            onSelect={() =>
+              handleCommand(() => setTestConfig({ duration: 60 }))
+            }
+          >
+            <span>60 seconds</span>
+          </CommandItem>
+          <CommandItem
+            onSelect={() =>
+              handleCommand(() => setTestConfig({ duration: 120 }))
+            }
+          >
+            <span>120 seconds</span>
+          </CommandItem>
+        </CommandGroup>
+
+        <CommandSeparator />
+
+        <CommandGroup heading="Difficulty">
+          <CommandItem
+            onSelect={() =>
+              handleCommand(() => setTestConfig({ difficulty: 'Normal' }))
+            }
+          >
+            <span>Normal Mode</span>
+          </CommandItem>
+          <CommandItem
+            onSelect={() =>
+              handleCommand(() => setTestConfig({ difficulty: 'Expert' }))
+            }
+          >
+            <span>Expert Mode</span>
+          </CommandItem>
+          <CommandItem
+            onSelect={() =>
+              handleCommand(() => setTestConfig({ difficulty: 'Master' }))
+            }
+          >
+            <span>Master Mode</span>
+          </CommandItem>
+        </CommandGroup>
+
+        <CommandSeparator />
+
+        <CommandGroup heading="Word List">
+          <CommandItem
+            onSelect={() =>
+              handleCommand(() => setTestConfig({ textSource: 'random' }))
+            }
+          >
+            <span>Random Words</span>
+          </CommandItem>
+          <CommandItem
+            onSelect={() =>
+              handleCommand(() => setTestConfig({ textSource: 'ai-generated' }))
+            }
+          >
+            <span>AI Generated</span>
+          </CommandItem>
+          <CommandItem
+            onSelect={() =>
+              handleCommand(() => setTestConfig({ textSource: 'custom' }))
+            }
+          >
+            <span>Custom Text</span>
+          </CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/src/components/core/CommandPalette.tsx
+++ b/src/components/core/CommandPalette.tsx
@@ -11,13 +11,15 @@ import {
   CommandSeparator,
 } from '@/components/ui/command';
 import { useGameStore } from '@/store/useGameStore';
+import { Check } from 'lucide-react';
 
 export function CommandPalette() {
   const [open, setOpen] = useState(false);
 
-  // Zustand store actions
+  // Zustand store actions and current config
   const setTestConfig = useGameStore((state) => state.setTestConfig);
   const resetGame = useGameStore((state) => state.resetGame);
+  const currentMode = useGameStore((state) => state.testConfig.mode);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -42,6 +44,35 @@ export function CommandPalette() {
       <CommandInput placeholder="Type a command or search..." />
       <CommandList>
         <CommandEmpty>No results found.</CommandEmpty>
+
+        <CommandGroup heading="Mode">
+          <CommandItem
+            onSelect={() =>
+              handleCommand(() => setTestConfig({ mode: 'time' }))
+            }
+          >
+            {currentMode === 'time' && <Check className="mr-2 h-4 w-4" />}
+            <span className={currentMode !== 'time' ? 'ml-6' : ''}>Time</span>
+          </CommandItem>
+          <CommandItem
+            onSelect={() =>
+              handleCommand(() => setTestConfig({ mode: 'words' }))
+            }
+          >
+            {currentMode === 'words' && <Check className="mr-2 h-4 w-4" />}
+            <span className={currentMode !== 'words' ? 'ml-6' : ''}>Words</span>
+          </CommandItem>
+          <CommandItem
+            onSelect={() =>
+              handleCommand(() => setTestConfig({ mode: 'quote' }))
+            }
+          >
+            {currentMode === 'quote' && <Check className="mr-2 h-4 w-4" />}
+            <span className={currentMode !== 'quote' ? 'ml-6' : ''}>Quote</span>
+          </CommandItem>
+        </CommandGroup>
+
+        <CommandSeparator />
 
         <CommandGroup heading="Game Controls">
           <CommandItem onSelect={() => handleCommand(() => resetGame())}>

--- a/src/components/core/CommandPalette.tsx
+++ b/src/components/core/CommandPalette.tsx
@@ -20,6 +20,8 @@ export function CommandPalette() {
   const setTestConfig = useGameStore((state) => state.setTestConfig);
   const resetGame = useGameStore((state) => state.resetGame);
   const currentMode = useGameStore((state) => state.testConfig.mode);
+  const currentDuration = useGameStore((state) => state.testConfig.duration);
+  const currentWordCount = useGameStore((state) => state.testConfig.wordCount);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -80,31 +82,101 @@ export function CommandPalette() {
           </CommandItem>
         </CommandGroup>
 
-        <CommandSeparator />
+        {currentMode === 'time' && (
+          <>
+            <CommandSeparator />
+            <CommandGroup heading="Duration">
+              <CommandItem
+                onSelect={() =>
+                  handleCommand(() => setTestConfig({ duration: 15 }))
+                }
+              >
+                {currentDuration === 15 && <Check className="mr-2 h-4 w-4" />}
+                <span className={currentDuration !== 15 ? 'ml-6' : ''}>
+                  15 seconds
+                </span>
+              </CommandItem>
+              <CommandItem
+                onSelect={() =>
+                  handleCommand(() => setTestConfig({ duration: 30 }))
+                }
+              >
+                {currentDuration === 30 && <Check className="mr-2 h-4 w-4" />}
+                <span className={currentDuration !== 30 ? 'ml-6' : ''}>
+                  30 seconds
+                </span>
+              </CommandItem>
+              <CommandItem
+                onSelect={() =>
+                  handleCommand(() => setTestConfig({ duration: 60 }))
+                }
+              >
+                {currentDuration === 60 && <Check className="mr-2 h-4 w-4" />}
+                <span className={currentDuration !== 60 ? 'ml-6' : ''}>
+                  60 seconds
+                </span>
+              </CommandItem>
+              <CommandItem
+                onSelect={() =>
+                  handleCommand(() => setTestConfig({ duration: 120 }))
+                }
+              >
+                {currentDuration === 120 && <Check className="mr-2 h-4 w-4" />}
+                <span className={currentDuration !== 120 ? 'ml-6' : ''}>
+                  120 seconds
+                </span>
+              </CommandItem>
+            </CommandGroup>
+          </>
+        )}
 
-        <CommandGroup heading="Duration">
-          <CommandItem
-            onSelect={() =>
-              handleCommand(() => setTestConfig({ duration: 30 }))
-            }
-          >
-            <span>30 seconds</span>
-          </CommandItem>
-          <CommandItem
-            onSelect={() =>
-              handleCommand(() => setTestConfig({ duration: 60 }))
-            }
-          >
-            <span>60 seconds</span>
-          </CommandItem>
-          <CommandItem
-            onSelect={() =>
-              handleCommand(() => setTestConfig({ duration: 120 }))
-            }
-          >
-            <span>120 seconds</span>
-          </CommandItem>
-        </CommandGroup>
+        {currentMode === 'words' && (
+          <>
+            <CommandSeparator />
+            <CommandGroup heading="Word Count">
+              <CommandItem
+                onSelect={() =>
+                  handleCommand(() => setTestConfig({ wordCount: 10 }))
+                }
+              >
+                {currentWordCount === 10 && <Check className="mr-2 h-4 w-4" />}
+                <span className={currentWordCount !== 10 ? 'ml-6' : ''}>
+                  10 words
+                </span>
+              </CommandItem>
+              <CommandItem
+                onSelect={() =>
+                  handleCommand(() => setTestConfig({ wordCount: 25 }))
+                }
+              >
+                {currentWordCount === 25 && <Check className="mr-2 h-4 w-4" />}
+                <span className={currentWordCount !== 25 ? 'ml-6' : ''}>
+                  25 words
+                </span>
+              </CommandItem>
+              <CommandItem
+                onSelect={() =>
+                  handleCommand(() => setTestConfig({ wordCount: 50 }))
+                }
+              >
+                {currentWordCount === 50 && <Check className="mr-2 h-4 w-4" />}
+                <span className={currentWordCount !== 50 ? 'ml-6' : ''}>
+                  50 words
+                </span>
+              </CommandItem>
+              <CommandItem
+                onSelect={() =>
+                  handleCommand(() => setTestConfig({ wordCount: 100 }))
+                }
+              >
+                {currentWordCount === 100 && <Check className="mr-2 h-4 w-4" />}
+                <span className={currentWordCount !== 100 ? 'ml-6' : ''}>
+                  100 words
+                </span>
+              </CommandItem>
+            </CommandGroup>
+          </>
+        )}
 
         <CommandSeparator />
 

--- a/src/components/core/CommandPalette.tsx
+++ b/src/components/core/CommandPalette.tsx
@@ -25,6 +25,12 @@ export function CommandPalette() {
   const currentDifficulty = useGameStore(
     (state) => state.testConfig.difficulty
   );
+  const currentTextSource = useGameStore(
+    (state) => state.testConfig.textSource
+  );
+  const currentPunctuation = useGameStore(
+    (state) => state.testConfig.punctuation
+  );
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -227,24 +233,56 @@ export function CommandPalette() {
         <CommandGroup heading="Word List">
           <CommandItem
             onSelect={() =>
-              handleCommand(() => setTestConfig({ textSource: 'random' }))
+              handleCommand(() => setTestConfig({ textSource: 'english-1k' }))
             }
           >
-            <span>Random Words</span>
+            {currentTextSource === 'english-1k' && (
+              <Check className="mr-2 h-4 w-4" />
+            )}
+            <span className={currentTextSource !== 'english-1k' ? 'ml-6' : ''}>
+              English 1k
+            </span>
           </CommandItem>
           <CommandItem
             onSelect={() =>
-              handleCommand(() => setTestConfig({ textSource: 'ai-generated' }))
+              handleCommand(() => setTestConfig({ textSource: 'javascript' }))
             }
           >
-            <span>AI Generated</span>
+            {currentTextSource === 'javascript' && (
+              <Check className="mr-2 h-4 w-4" />
+            )}
+            <span className={currentTextSource !== 'javascript' ? 'ml-6' : ''}>
+              JavaScript
+            </span>
           </CommandItem>
           <CommandItem
             onSelect={() =>
-              handleCommand(() => setTestConfig({ textSource: 'custom' }))
+              handleCommand(() => setTestConfig({ textSource: 'python' }))
             }
           >
-            <span>Custom Text</span>
+            {currentTextSource === 'python' && (
+              <Check className="mr-2 h-4 w-4" />
+            )}
+            <span className={currentTextSource !== 'python' ? 'ml-6' : ''}>
+              Python
+            </span>
+          </CommandItem>
+        </CommandGroup>
+
+        <CommandSeparator />
+
+        <CommandGroup heading="Modifiers">
+          <CommandItem
+            onSelect={() =>
+              handleCommand(() =>
+                setTestConfig({ punctuation: !currentPunctuation })
+              )
+            }
+          >
+            {currentPunctuation && <Check className="mr-2 h-4 w-4" />}
+            <span className={!currentPunctuation ? 'ml-6' : ''}>
+              Punctuation
+            </span>
           </CommandItem>
         </CommandGroup>
       </CommandList>

--- a/src/components/core/CommandPalette.tsx
+++ b/src/components/core/CommandPalette.tsx
@@ -22,6 +22,9 @@ export function CommandPalette() {
   const currentMode = useGameStore((state) => state.testConfig.mode);
   const currentDuration = useGameStore((state) => state.testConfig.duration);
   const currentWordCount = useGameStore((state) => state.testConfig.wordCount);
+  const currentDifficulty = useGameStore(
+    (state) => state.testConfig.difficulty
+  );
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -186,21 +189,36 @@ export function CommandPalette() {
               handleCommand(() => setTestConfig({ difficulty: 'Normal' }))
             }
           >
-            <span>Normal Mode</span>
+            {currentDifficulty === 'Normal' && (
+              <Check className="mr-2 h-4 w-4" />
+            )}
+            <span className={currentDifficulty !== 'Normal' ? 'ml-6' : ''}>
+              Normal Mode
+            </span>
           </CommandItem>
           <CommandItem
             onSelect={() =>
               handleCommand(() => setTestConfig({ difficulty: 'Expert' }))
             }
           >
-            <span>Expert Mode</span>
+            {currentDifficulty === 'Expert' && (
+              <Check className="mr-2 h-4 w-4" />
+            )}
+            <span className={currentDifficulty !== 'Expert' ? 'ml-6' : ''}>
+              Expert Mode
+            </span>
           </CommandItem>
           <CommandItem
             onSelect={() =>
               handleCommand(() => setTestConfig({ difficulty: 'Master' }))
             }
           >
-            <span>Master Mode</span>
+            {currentDifficulty === 'Master' && (
+              <Check className="mr-2 h-4 w-4" />
+            )}
+            <span className={currentDifficulty !== 'Master' ? 'ml-6' : ''}>
+              Master Mode
+            </span>
           </CommandItem>
         </CommandGroup>
 

--- a/src/components/game/ConfigurationBar.tsx
+++ b/src/components/game/ConfigurationBar.tsx
@@ -11,16 +11,17 @@ export function ConfigurationBar() {
   const duration = useGameStore((state) => state.testConfig.duration);
   const wordCount = useGameStore((state) => state.testConfig.wordCount);
   const textSource = useGameStore((state) => state.testConfig.textSource);
+  const punctuation = useGameStore((state) => state.testConfig.punctuation);
   const customText = useGameStore((state) => state.testConfig.customText);
 
   const getTextSourceDisplay = (textSource: string) => {
     switch (textSource) {
-      case 'random':
-        return 'Random Words';
-      case 'custom':
-        return 'Custom Text';
-      case 'ai-generated':
-        return 'AI Generated';
+      case 'english-1k':
+        return 'English 1k';
+      case 'javascript':
+        return 'JavaScript';
+      case 'python':
+        return 'Python';
       default:
         return textSource;
     }
@@ -89,6 +90,17 @@ export function ConfigurationBar() {
           {getTextSourceDisplay(textSource)}
         </Badge>
       </div>
+
+      {punctuation && (
+        <div className="flex items-center gap-2">
+          <Badge
+            variant="outline"
+            className="hover:bg-primary hover:text-primary-foreground cursor-pointer transition-colors"
+          >
+            Punctuation
+          </Badge>
+        </div>
+      )}
 
       {textSource === 'custom' && customText && (
         <div className="flex items-center gap-2">

--- a/src/components/game/ConfigurationBar.tsx
+++ b/src/components/game/ConfigurationBar.tsx
@@ -9,6 +9,7 @@ export function ConfigurationBar() {
   const mode = useGameStore((state) => state.testConfig.mode);
   const difficulty = useGameStore((state) => state.testConfig.difficulty);
   const duration = useGameStore((state) => state.testConfig.duration);
+  const wordCount = useGameStore((state) => state.testConfig.wordCount);
   const textSource = useGameStore((state) => state.testConfig.textSource);
   const customText = useGameStore((state) => state.testConfig.customText);
 
@@ -49,17 +50,33 @@ export function ConfigurationBar() {
         </Badge>
       </div>
 
-      <div className="flex items-center gap-2">
-        <span className="text-muted-foreground text-sm font-medium">
-          Duration:
-        </span>
-        <Badge
-          variant="secondary"
-          className="hover:bg-primary hover:text-primary-foreground cursor-pointer transition-colors"
-        >
-          {duration}s
-        </Badge>
-      </div>
+      {mode === 'time' && (
+        <div className="flex items-center gap-2">
+          <span className="text-muted-foreground text-sm font-medium">
+            Duration:
+          </span>
+          <Badge
+            variant="secondary"
+            className="hover:bg-primary hover:text-primary-foreground cursor-pointer transition-colors"
+          >
+            {duration}s
+          </Badge>
+        </div>
+      )}
+
+      {mode === 'words' && (
+        <div className="flex items-center gap-2">
+          <span className="text-muted-foreground text-sm font-medium">
+            Word Count:
+          </span>
+          <Badge
+            variant="secondary"
+            className="hover:bg-primary hover:text-primary-foreground cursor-pointer transition-colors"
+          >
+            {wordCount} words
+          </Badge>
+        </div>
+      )}
 
       <div className="flex items-center gap-2">
         <span className="text-muted-foreground text-sm font-medium">

--- a/src/components/game/ConfigurationBar.tsx
+++ b/src/components/game/ConfigurationBar.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge';
 
 export function ConfigurationBar() {
   // Use atomic selectors to prevent infinite loop and optimize performance
+  const mode = useGameStore((state) => state.testConfig.mode);
   const difficulty = useGameStore((state) => state.testConfig.difficulty);
   const duration = useGameStore((state) => state.testConfig.duration);
   const textSource = useGameStore((state) => state.testConfig.textSource);
@@ -28,6 +29,18 @@ export function ConfigurationBar() {
     <div className="bg-card flex flex-wrap items-center gap-3 rounded-lg border p-4">
       <div className="flex items-center gap-2">
         <span className="text-muted-foreground text-sm font-medium">Mode:</span>
+        <Badge
+          variant="secondary"
+          className="hover:bg-primary hover:text-primary-foreground cursor-pointer transition-colors"
+        >
+          {mode.charAt(0).toUpperCase() + mode.slice(1)}
+        </Badge>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <span className="text-muted-foreground text-sm font-medium">
+          Difficulty:
+        </span>
         <Badge
           variant="secondary"
           className="hover:bg-primary hover:text-primary-foreground cursor-pointer transition-colors"

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import * as React from 'react';
+import { Command as CommandPrimitive } from 'cmdk';
+import { SearchIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        'bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandDialog({
+  title = 'Command Palette',
+  description = 'Search for a command to run...',
+  children,
+  className,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string;
+  description?: string;
+  className?: string;
+  showCloseButton?: boolean;
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className={cn('overflow-hidden p-0', className)}
+        showCloseButton={showCloseButton}
+      >
+        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div
+      data-slot="command-input-wrapper"
+      className="flex h-9 items-center gap-2 border-b px-3"
+    >
+      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          'placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
+          className
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        'max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  );
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        'text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn('bg-border -mx-1 h-px', className)}
+      {...props}
+    />
+  );
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.ComponentProps<'span'>) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn(
+        'text-muted-foreground ml-auto text-xs tracking-widest',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+};

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { XIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      {...props}
+    />
+  );
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn('text-lg leading-none font-semibold', className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn('text-muted-foreground text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 
 // Test Configuration Interface
 interface TestConfig {
+  mode: 'time' | 'words' | 'quote'; // Test mode
   duration: number; // Test duration in seconds
   difficulty: 'Normal' | 'Expert' | 'Master';
   textSource: 'random' | 'custom' | 'ai-generated';
@@ -53,6 +54,7 @@ interface GameState {
 
 // Default values
 const defaultTestConfig: TestConfig = {
+  mode: 'time',
   duration: 60,
   difficulty: 'Normal',
   textSource: 'random',

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -6,7 +6,8 @@ interface TestConfig {
   duration: number; // Test duration in seconds
   wordCount: 10 | 25 | 50 | 100; // Word count for words mode
   difficulty: 'Normal' | 'Expert' | 'Master';
-  textSource: 'random' | 'custom' | 'ai-generated';
+  textSource: 'english-1k' | 'javascript' | 'python';
+  punctuation: boolean; // Include punctuation in text
   customText?: string;
 }
 
@@ -59,7 +60,8 @@ const defaultTestConfig: TestConfig = {
   duration: 60,
   wordCount: 50,
   difficulty: 'Normal',
-  textSource: 'random',
+  textSource: 'english-1k',
+  punctuation: false,
 };
 
 const defaultStats: GameStats = {

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -4,6 +4,7 @@ import { create } from 'zustand';
 interface TestConfig {
   mode: 'time' | 'words' | 'quote'; // Test mode
   duration: number; // Test duration in seconds
+  wordCount: 10 | 25 | 50 | 100; // Word count for words mode
   difficulty: 'Normal' | 'Expert' | 'Master';
   textSource: 'random' | 'custom' | 'ai-generated';
   customText?: string;
@@ -56,6 +57,7 @@ interface GameState {
 const defaultTestConfig: TestConfig = {
   mode: 'time',
   duration: 60,
+  wordCount: 50,
   difficulty: 'Normal',
   textSource: 'random',
 };


### PR DESCRIPTION
This PR introduces the fully functional Command Palette, allowing users to control all test settings via a keyboard-driven interface (Ctrl+K) as specified in the GDD.

## Features Added
- Complete Command Palette UI with keyboard shortcut (Ctrl/Cmd+K)
- Mode selection (Time, Words, Quote)
- Duration settings for time mode (15s, 30s, 60s, 120s)
- Word count settings for words mode (10, 25, 50, 100 words)
- Difficulty selection (Normal, Expert, Master)
- Word List selection (English 1k, JavaScript, Python)
- Punctuation toggle
- Visual feedback with checkmarks for active selections
- ConfigurationBar displays all selected settings

🤖 Generated with [Claude Code](https://claude.ai/code)