### PR TITLE
Fix: Add Prisma Generate to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Generate Prisma Client
+        run: npm run generate --workspace=@typeamp/api
+
       - name: Lint the Frontend
         run: npm run lint --workspace=type
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "tsc --noEmit"
+    "build": "tsc --noEmit",
+    "generate": "prisma generate"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.56.0",


### PR DESCRIPTION
## Summary
- Add Prisma generate step to CI workflow to fix build failures
- Add generate script to backend package.json

## Problem
The CI was failing with error `Cannot find module '../generated/prisma/index.js'` because Prisma Client was not being generated in the CI environment.

## Solution
- Added `"generate": "prisma generate"` script to `packages/api/package.json`
- Added "Generate Prisma Client" step in CI workflow after installing dependencies and before building the backend

## Test plan
- [x] CI workflow should pass after this change
- [x] Backend build should succeed with generated Prisma client

🤖 Generated with [Claude Code](https://claude.ai/code)