### PR TITLE
feat: Add Sign-Up Prompt to Profile Page

### DIFF
--- a/packages/web/src/app/profile/page.tsx
+++ b/packages/web/src/app/profile/page.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/components/ui/card';
 import { HistoryGraph } from '@/components/profile/HistoryGraph';
 import { SummaryCard } from '@/components/profile/SummaryCard';
+import { SignUpAlert } from '@/components/profile/SignUpAlert';
 
 // API test result interface (from backend)
 interface ApiTestResult {
@@ -159,6 +160,9 @@ export default function ProfilePage() {
 
   return (
     <div className="container mx-auto max-w-7xl px-6 py-8">
+      {/* Sign-up alert for anonymous users */}
+      {!token && <SignUpAlert />}
+
       <div className="mb-8">
         <h1 className="mb-2 text-3xl font-bold">Profile</h1>
         <p className="text-muted-foreground">

--- a/packages/web/src/components/profile/SignUpAlert.tsx
+++ b/packages/web/src/components/profile/SignUpAlert.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { useModalStore } from '@/store/useModalStore';
+import { UserPlus } from 'lucide-react';
+
+export function SignUpAlert() {
+  const { openAuthModal } = useModalStore();
+
+  const handleSignUp = () => {
+    openAuthModal();
+  };
+
+  return (
+    <Alert className="mb-6">
+      <UserPlus className="h-4 w-4" />
+      <AlertTitle>Sync Your Progress</AlertTitle>
+      <AlertDescription>
+        <Button
+          variant="link"
+          className="h-auto p-0 text-sm font-normal"
+          onClick={handleSignUp}
+        >
+          Create a free account
+        </Button>{' '}
+        to sync your history across devices.
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/packages/web/src/components/ui/alert.tsx
+++ b/packages/web/src/components/ui/alert.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const alertVariants = cva(
+  'relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current',
+  {
+    variants: {
+      variant: {
+        default: 'bg-card text-card-foreground',
+        destructive:
+          'text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<'div'> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        'col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        'text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Alert, AlertTitle, AlertDescription };


### PR DESCRIPTION
This PR adds a non-intrusive alert to the profile page for anonymous users, prompting them to create an account to sync their history.

## Features Added
- Alert component from shadcn/ui for polished appearance
- SignUpAlert component with "Sync Your Progress" messaging
- Conditional rendering - only shows for anonymous users
- Call-to-action button opens existing auth modal
- Clean integration with existing profile page layout

## User Experience
- Anonymous users see a helpful prompt at the top of the profile page
- Authenticated users see the profile page without any alert
- Single click opens the login/register modal
- Non-intrusive design that enhances the UX

🤖 Generated with [Claude Code](https://claude.ai/code)